### PR TITLE
Fix(ime): prevent keyboard overlap; fix Add Note overlap; block empty titles

### DIFF
--- a/app/src/main/java/com/lahsuak/apps/tasks/ui/MainActivity.kt
+++ b/app/src/main/java/com/lahsuak/apps/tasks/ui/MainActivity.kt
@@ -23,6 +23,9 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imeNestedScroll
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -94,7 +97,6 @@ class MainActivity : AppCompatActivity() {
     private val updateLauncher = registerForActivityResult(
         ActivityResultContracts.StartIntentSenderForResult()
     ) { result ->
-        // handle callback
         if (result.data == null) return@registerForActivityResult
         if (result.resultCode == UPDATE_REQUEST_CODE) {
             toast { getString(R.string.downloading_start) }
@@ -179,24 +181,34 @@ class MainActivity : AppCompatActivity() {
                     )
                 )
                 Surface(Modifier.background(MaterialTheme.colorScheme.background)) {
-                    if (isScreenLoaded) {
-                        TaskNavHost(
-                            taskViewModel,
-                            subTaskViewModel,
-                            notificationViewModel,
-                            settingViewModel,
-                            navController,
-                            settingPreferences = settingsPreferences,
-                            windowSize = rememberWindowSize(),
-                            noteViewModel =noteViewModel
-                        )
-                    } else {
-                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            Image(
-                                painter = painterResource(id = R.drawable.logo_icon),
-                                contentDescription = null,
-                                modifier = Modifier.size(120.dp)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .imePadding()
+                            .navigationBarsPadding()
+                    ) {
+                        if (isScreenLoaded) {
+                            TaskNavHost(
+                                taskViewModel,
+                                subTaskViewModel,
+                                notificationViewModel,
+                                settingViewModel,
+                                navController,
+                                settingPreferences = settingsPreferences,
+                                windowSize = rememberWindowSize(),
+                                noteViewModel = noteViewModel
                             )
+                        } else {
+                            Box(
+                                Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Image(
+                                    painter = painterResource(id = R.drawable.logo_icon),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(120.dp)
+                                )
+                            }
                         }
                     }
                 }
@@ -244,7 +256,6 @@ class MainActivity : AppCompatActivity() {
                     val theme = preference.theme.toInt()
                     val currentNightMode =
                         resources.configuration.uiMode and UI_MODE_NIGHT_MASK
-                    //32 = dark mode and 16 = light mode
                     if (currentNightMode / 16 != if (theme == -1) {
                             0
                         } else theme
@@ -255,7 +266,6 @@ class MainActivity : AppCompatActivity() {
             }
         }
     }
-
 
     @Composable
     internal fun SetupTransparentSystemUi(
@@ -285,9 +295,7 @@ class MainActivity : AppCompatActivity() {
             rememberLauncherForActivityResult(
                 ActivityResultContracts.RequestPermission()
             ) { isGranted: Boolean ->
-                if (isGranted) {
-                    /* no-op */
-                } else {
+                if (!isGranted) {
                     toast {
                         getString(R.string.user_cancelled_the_operation)
                     }
@@ -299,18 +307,13 @@ class MainActivity : AppCompatActivity() {
                 LocalContext.current,
                 android.Manifest.permission.POST_NOTIFICATIONS
             ),
-            -> {
-                // Some works that require permission
-            }
-
+                -> { }
             else -> {
-                // Asking for permission
                 SideEffect {
                     launcher.launch(android.Manifest.permission.POST_NOTIFICATIONS)
                 }
             }
         }
-
     }
 
     private fun checkUpdate() {

--- a/app/src/main/java/com/lahsuak/apps/tasks/ui/screens/TaskScreen.kt
+++ b/app/src/main/java/com/lahsuak/apps/tasks/ui/screens/TaskScreen.kt
@@ -41,9 +41,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ExperimentalMaterialApi
-//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.ModalBottomSheetLayout
-//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -128,6 +126,7 @@ import com.jaixlabs.checksy.util.WindowSize
 import com.jaixlabs.checksy.util.WindowType
 import com.jaixlabs.checksy.util.preference.FilterPreferences
 import com.jaixlabs.checksy.util.preference.SettingPreferences
+import com.jaixlabs.checksy.util.toast
 import kotlinx.coroutines.launch
 import kotlin.random.Random
 import androidx.compose.foundation.lazy.LazyColumn as LazyColumn1
@@ -158,7 +157,6 @@ fun TaskScreen(
     )
     val showVoiceTask = settingsPreferences.showVoiceIcon
 
-
     var taskId: String? by rememberSaveable {
         mutableStateOf(null)
     }
@@ -167,7 +165,6 @@ fun TaskScreen(
     }
     val noteList = noteViewModel?.noteList?.collectAsState()?.value ?: emptyList()
 
-
     var isBottomSheetOpened by rememberSaveable {
         mutableStateOf(false)
     }
@@ -175,16 +172,6 @@ fun TaskScreen(
     var searchQuery by rememberSaveable {
         mutableStateOf("")
     }
-//    val notes = stringResource(R.string.notes)
-//    val active = stringResource(R.string.active)
-//    val done = stringResource(R.string.done)
-//    val status = remember {
-//        mutableStateListOf(notes, active, done)
-//    }
-//    var isTaskDone by rememberSaveable {
-//        mutableStateOf(false)
-//    }
-//    var isNotes by rememberSaveable { mutableStateOf(false) }
     val notes = stringResource(R.string.notes)
     val active = stringResource(R.string.active)
     val done = stringResource(R.string.done)
@@ -194,13 +181,14 @@ fun TaskScreen(
     }
 
     var isTaskDone by rememberSaveable {
-        mutableStateOf(TaskStatus.isTaskDone) // ✅ Global state sync
+        mutableStateOf(TaskStatus.isTaskDone)
     }
 
     var isNotes by rememberSaveable {
-        mutableStateOf(TaskStatus.isNotes) // ✅ Global state sync
+        mutableStateOf(TaskStatus.isNotes)
     }
 
+    val context = LocalContext.current
 
     val speakLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
@@ -208,19 +196,23 @@ fun TaskScreen(
         if (result.resultCode == Activity.RESULT_OK) {
             val data = result.data
             val result1 = data!!.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
-            val task = Task(
-                id = 0,
-                title = result1!![0],
-                startDate = System.currentTimeMillis()
-            )
-            taskViewModel.insert(task)
+            val spoken = result1?.firstOrNull()?.trim().orEmpty()
+            if (spoken.isNotEmpty()) {
+                val task = Task(
+                    id = 0,
+                    title = spoken,
+                    startDate = System.currentTimeMillis()
+                )
+                taskViewModel.insert(task)
+            } else {
+                context.toast { context.getString(R.string.empty_task) }
+            }
         }
     }
 
     var isListViewEnable by rememberSaveable {
         mutableStateOf(preference.viewType)
     }
-    val context = LocalContext.current
 
     val snackBarHostState = remember {
         SnackbarHostState()
@@ -336,7 +328,6 @@ fun TaskScreen(
         }
     }
 
-    // ✅ Ensure state updates globally
     LaunchedEffect(isTaskDone, isNotes) {
         TaskStatus.isTaskDone = isTaskDone
         TaskStatus.isNotes = isNotes
@@ -407,9 +398,6 @@ fun TaskScreen(
         val isFabExtended by remember {
             derivedStateOf { lazyGridListState.firstVisibleItemIndex != 0 }
         }
-
-
-
 
         Scaffold(
             topBar = {
@@ -517,10 +505,10 @@ fun TaskScreen(
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp),
                         horizontalArrangement =
-                        if (isTaskDone || isNotes)
-                            Arrangement.Center
-                        else
-                            Arrangement.SpaceBetween,
+                            if (isTaskDone || isNotes)
+                                Arrangement.Center
+                            else
+                                Arrangement.SpaceBetween,
                     ) {
                         AnimatedVisibility(visible = showVoiceTask && !isTaskDone && !isNotes) {
                             FloatingActionButton(
@@ -535,13 +523,12 @@ fun TaskScreen(
                             }
                         }
 
-                        // ✅ Notes Mode Me "Add Note" Button Show Karna
                         AnimatedVisibility(visible = isNotes) {
                             FloatingActionButton(
                                 containerColor = MaterialTheme.colorScheme.primary,
                                 modifier = Modifier
-                                    .padding(16.dp) // ✅ Proper padding
-                                    .size(60.dp), // ✅ Right Bottom Position
+                                    .padding(16.dp)
+                                    .size(60.dp),
                                 shape = CircleShape,
                                 onClick = {
                                     navController?.currentBackStackEntry?.savedStateHandle?.set(
@@ -561,7 +548,6 @@ fun TaskScreen(
 
                         }
 
-                        // ✅ Completed Tasks Delete Button
                         AnimatedVisibility(visible = isTaskDone) {
                             FloatingActionButton(
                                 containerColor = MaterialTheme.colorScheme.error,
@@ -575,7 +561,6 @@ fun TaskScreen(
                                     stringResource(R.string.delete_task)
                                 )
                             }
-                            // ✅ Jab `isNoteScreenVisible` true ho, tab Notes Screen Show Karo
                             if (isNoteScreenVisible) {
                                 if (noteViewModel != null) {
                                     NoteScreenNavigation(context, noteViewModel)
@@ -583,7 +568,6 @@ fun TaskScreen(
                             }
                         }
 
-                        // ✅ Notes aur Completed ke alawa Add Task Button Show Karna
                         AnimatedVisibility(visible = !isTaskDone && !isNotes) {
                             if (isFabExtended) {
                                 ExtendedFloatingActionButton(
@@ -693,12 +677,11 @@ fun TaskScreen(
                     }
                 ),
             ) {
-                // ✅ Status Selection aur HeaderContent
                 item(span = StaggeredGridItemSpan.FullLine) {
                     AnimatedVisibility(!actionMode) {
                         HeaderContent(
-                            completedTask = if (isNotes) 0 else tasks.count { it.isDone }, // ✅ Completed Tasks Count (0 for Notes)
-                            totalTask = if (isNotes) noteList.size else tasks.size, // ✅ Total Notes or Tasks Count,
+                            completedTask = if (isNotes) 0 else tasks.count { it.isDone },
+                            totalTask = if (isNotes) noteList.size else tasks.size,
                             searchQuery = searchQuery,
                             onQueryChange = {
                                 searchQuery = it
@@ -719,19 +702,19 @@ fun TaskScreen(
                             },
                             onStatusChange = { index: Int ->
                                 when (index) {
-                                    0 -> { // ✅ Notes Selected
+                                    0 -> {
                                         isNotes = true
                                         isTaskDone = false
                                         isNoteScreenVisible = true
                                     }
 
-                                    1 -> { // ✅ Active Selected
+                                    1 -> {
                                         isNotes = false
                                         isTaskDone = false
                                         isNoteScreenVisible = false
                                     }
 
-                                    2 -> { // ✅ Done Selected
+                                    2 -> {
                                         isNotes = false
                                         isTaskDone = true
                                         isNoteScreenVisible = false
@@ -764,27 +747,23 @@ fun TaskScreen(
                         )
                     }
                 }
-                // ✅ Apply Search & Sort Based on Selection
                 val filteredList = if (isNotes) {
                     noteList.filter { it.title.contains(searchQuery, ignoreCase = true) }
-                        .sortedByDescending { it.timeStamp } // ✅ Notes Sorted by Date (Latest First)
+                        .sortedByDescending { it.timeStamp }
                 } else {
                     tasks.filter { t ->
                         when {
-                            isTaskDone -> t.isDone // ✅ Done wale tasks show honge
+                            isTaskDone -> t.isDone
                             isNotes -> !t.isDone && (t.category
-                                ?: "") == "Notes" // ✅ Notes wale show honge
-                            else -> !t.isDone // ✅ Active wale tasks show honge
+                                ?: "") == "Notes"
+                            else -> !t.isDone
                         }
-                    }.filter { it.title.contains(searchQuery, ignoreCase = true) } // ✅ Apply Search
-                        .sortedByDescending { it.isImp } // ✅ Important Tasks Pehle Dikhaye
+                    }.filter { it.title.contains(searchQuery, ignoreCase = true) }
+                        .sortedByDescending { it.isImp }
                 }
 
-
-                // ✅ Notes & Tasks Handling
                 if (isNotes) {
                     if (filteredList.isEmpty()) {
-                        // ✅ Empty Notes Message
                         item(span = StaggeredGridItemSpan.FullLine) {
                             Box(
                                 modifier = Modifier
@@ -818,7 +797,6 @@ fun TaskScreen(
                             }
                         }
                     } else {
-                        // ✅ Show Sorted and Filtered Notes
                         items(filteredList) { note ->
                             NoteRow(
                                 note = note as Note,
@@ -828,10 +806,10 @@ fun TaskScreen(
                                         key = "note_obj",
                                         value = note
                                     )
-                                    navController?.navigate("NoteScreen") // ✅ Open Note Screen
+                                    navController?.navigate("NoteScreen")
                                 },
                                 onDeleteNote = {
-                                    noteViewModel?.deleteNote(note.id) // ✅ Delete Note from DB
+                                    noteViewModel?.deleteNote(note.id)
                                 },
                                 onEditNote = {
                                     navController?.currentBackStackEntry?.savedStateHandle?.set(
@@ -845,13 +823,12 @@ fun TaskScreen(
                                         note.id,
                                         isLocked,
                                         password
-                                    ) // ✅ Update Lock Status in DB
+                                    )
                                 }
                             )
                         }
                     }
                 } else {
-                    // ✅ Active & Done Tasks
                     items(
                         filteredList.filterIsInstance<Task>(),
                         key = { task: Task -> task.id + Random.nextInt() }) { task ->
@@ -1001,7 +978,6 @@ fun HeaderContent(
                         .clip(RoundedCornerShape(8.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant)
                         .onGloballyPositioned { coordinates ->
-                            //This value is used to assign to the DropDown the same width
                             mTextFieldSize = coordinates.size.toSize()
                         }
                         .toggleable(value = isDropDownExpanded) {

--- a/app/src/main/java/com/lahsuak/apps/tasks/ui/screens/dialog/AddUpdateSubTaskSceen.kt
+++ b/app/src/main/java/com/lahsuak/apps/tasks/ui/screens/dialog/AddUpdateSubTaskSceen.kt
@@ -7,12 +7,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ExperimentalMaterialApi
-//noinspection UsingMaterialAndMaterial3Libraries
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -108,6 +109,8 @@ fun AddUpdateSubTaskScreen(
     Column(
         Modifier
             .fillMaxWidth()
+            .navigationBarsPadding()
+            .imePadding()
             .padding(vertical = 8.dp)
     ) {
         RoundedOutlinedTextField(
@@ -128,26 +131,26 @@ fun AddUpdateSubTaskScreen(
                 .focusRequester(focusRequester)
                 .padding(horizontal = 8.dp),
             trailingIcon = {
-                Icon(painterResource( R.drawable.ic_paste), stringResource(
-                     R.string.paste),
-                Modifier.clickable {
-                    val pastedText = AppUtil.pasteText(context)
-                    title = pastedText
-                })
+                Icon(painterResource(R.drawable.ic_paste), stringResource(
+                    R.string.paste),
+                    Modifier.clickable {
+                        val pastedText = AppUtil.pasteText(context)
+                        title = pastedText
+                    })
             }
         )
         Row(verticalAlignment = Alignment.CenterVertically) {
             CheckBoxWithText(
-                text = stringResource( R.string.important_task),
+                text = stringResource(R.string.important_task),
                 value = isImp,
                 onValueChange = { isImp = it },
                 fontSize = 12.sp,
                 modifier = Modifier.padding(start = 4.dp)
             )
             TextButton(onClick = { AppUtil.setClipboard(context, title) }) {
-                Icon(painterResource( R.drawable.ic_copy), stringResource(R.string.copy_text))
+                Icon(painterResource(R.drawable.ic_copy), stringResource(R.string.copy_text))
                 Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource( R.string.copy_text), fontSize = 12.sp)
+                Text(stringResource(R.string.copy_text), fontSize = 12.sp)
             }
         }
         Row(


### PR DESCRIPTION
What

Make UI keyboard-aware so fields stay visible.

Fix Add Note bottom sheet overlapping content.

Prevent creating tasks with empty/whitespace titles (voice add).

Why

On some devices (e.g., Motorola E15) the IME overlapped inputs.

Bottom sheet also hid content in certain cases.

Empty titles reduced data quality.

Changes

MainActivity: wrap app content with imePadding(), imeNestedScroll(), navigationBarsPadding().

AddUpdateSubTaskScreen: add imePadding() + navigationBarsPadding() to root Column.

TaskScreen: ignore blank/whitespace speech; show existing “empty_task” toast.

How to test

Active screen → focus a text field → keyboard opens → field remains visible.

Open Add/Sub Task sheet → focus input → no overlap with IME/nav bar.

Voice add:

Silence/whitespace → no task created; toast shown.

Valid text → task created.

Fixes #1
Fixes #2